### PR TITLE
Improve Foxglove Bridge Client

### DIFF
--- a/raspberry-pi-android-client/app/src/main/java/com/shusuke/raspberry_pi_client/data/infrastructure/foxglove_bridge/FoxgloveBridgeClient.kt
+++ b/raspberry-pi-android-client/app/src/main/java/com/shusuke/raspberry_pi_client/data/infrastructure/foxglove_bridge/FoxgloveBridgeClient.kt
@@ -2,6 +2,7 @@ package com.shusuke.raspberry_pi_client.data.infrastructure.foxglove_bridge
 
 import android.util.Log
 import com.shusuke.raspberry_pi_client.data.infrastructure.foxglove_bridge.binary.FoxgloveBinaryMessageEncoder
+import com.shusuke.raspberry_pi_client.data.infrastructure.util.BinaryLogHelpers
 import com.shusuke.raspberry_pi_client.data.infrastructure.foxglove_bridge.binary.FoxgloveBinaryMessageParser
 import com.shusuke.raspberry_pi_client.data.infrastructure.foxglove_bridge.binary.FoxgloveServerBinaryMessage
 import com.shusuke.raspberry_pi_client.data.infrastructure.foxglove_bridge.common.FoxgloveJsonMessageParser
@@ -153,6 +154,7 @@ class FoxgloveBridgeClient(
                 sendClientAdvertise(topic.topic, channelId, schemaName)
             }
             val binaryData = FoxgloveBinaryMessageEncoder.encodeClientMessageData(channelId, payloadBytes)
+            Log.d("test", "send(encodeClientMessageData): ${BinaryLogHelpers.toHexString(binaryData)}")
             webSocketClient.send(binaryData)
         }
     }
@@ -464,6 +466,7 @@ class FoxgloveBridgeClient(
                 encoding = requestEncoding.wireName,
                 payload = payloadBytes,
             )
+            Log.d("FoxgloveBridgeClient", "send(encodeServiceCallRequest): ${BinaryLogHelpers.toHexString(binaryData)}")
             webSocketClient.send(binaryData)
         }
     }

--- a/raspberry-pi-android-client/app/src/main/java/com/shusuke/raspberry_pi_client/data/infrastructure/foxglove_bridge/FoxgloveBridgeClient.kt
+++ b/raspberry-pi-android-client/app/src/main/java/com/shusuke/raspberry_pi_client/data/infrastructure/foxglove_bridge/FoxgloveBridgeClient.kt
@@ -361,10 +361,9 @@ class FoxgloveBridgeClient(
                     )
                 }
                 FoxgloveWireEncoding.Cdr -> {
-                    Log.d("test", "CDR !!!!")
                     val args = service.args
-                    val encoder = cdrEncoder
-                    if (encoder == null || args == null) {
+                    Log.d("test", "CDR !!!!, encoder=$cdrEncoder, args=$args")
+                    if (cdrEncoder == null || args == null) {
                         onMessage(
                             Result.failure(
                                 RosServiceError.FailedReceiveMessage(
@@ -374,7 +373,7 @@ class FoxgloveBridgeClient(
                         )
                         return@launch
                     }
-                    runCatching { encoder(args) }.fold(
+                    runCatching { cdrEncoder(args) }.fold(
                         onSuccess = { it },
                         onFailure = {
                             onMessage(Result.failure(RosServiceError.FailedReceiveMessage(it)))

--- a/raspberry-pi-android-client/app/src/main/java/com/shusuke/raspberry_pi_client/data/infrastructure/foxglove_bridge/binary/FoxgloveBinaryMessageEncoder.kt
+++ b/raspberry-pi-android-client/app/src/main/java/com/shusuke/raspberry_pi_client/data/infrastructure/foxglove_bridge/binary/FoxgloveBinaryMessageEncoder.kt
@@ -15,9 +15,10 @@ object FoxgloveBinaryMessageEncoder {
 
     /**
      * Client Message Data（opcode 0x01）をエンコードする
+     * データ形式 [opcode 1Byte][channelId 4Byte][payload NByte]
      *
      * @param channelId Client Advertise で登録したチャンネル ID
-     * @param payload メッセージペイロード（JSON エンコード済みなど）
+     * @param payload メッセージペイロード（CDR エンコード済みなど）
      * @return 送信用バイナリデータ
      */
     fun encodeClientMessageData(channelId: UInt, payload: ByteArray): ByteArray {
@@ -31,10 +32,11 @@ object FoxgloveBinaryMessageEncoder {
 
     /**
      * Service Call Request（opcode 0x02）をエンコードする
+     * データ形式 [opcode 1Byte][serviceId 4Byte][callId 4Byte][encoding length 4Byte][payload NByte]
      *
-     * @param serviceId Advertise Services で取得したサービス ID
-     * @param callId レスポンスと対応付けるための一意な ID
-     * @param encoding エンコーディング名（例: "json"）
+     * @param serviceId Advertise Services で取得したサービス ID（/spawn のようなサービス名を識別するID）
+     * @param callId レスポンスと対応付けるための一意な ID（各リクエストごとに発行されるID、同じサービスが複数回呼ばれても良いようにリクエスト・レスポンスを紐づけるためのID）
+     * @param encoding エンコーディング名（"json", "cdr"）
      * @param payload リクエストペイロード
      * @return 送信用バイナリデータ
      */

--- a/raspberry-pi-android-client/app/src/main/java/com/shusuke/raspberry_pi_client/data/infrastructure/foxglove_bridge/binary/FoxgloveBinaryMessageParser.kt
+++ b/raspberry-pi-android-client/app/src/main/java/com/shusuke/raspberry_pi_client/data/infrastructure/foxglove_bridge/binary/FoxgloveBinaryMessageParser.kt
@@ -43,7 +43,7 @@ object FoxgloveBinaryMessageParser {
             return FoxgloveServerBinaryMessage.Unknown(opcode = OPCODE_MESSAGE_DATA, error = FoxgloveBinaryParseError.InsufficientData)
         }
         val buffer = ByteBuffer.wrap(data).order(ByteOrder.LITTLE_ENDIAN)
-        val subscriptionId = buffer.int.toUInt() //and 0xFFFFFFFFu
+        val subscriptionId = buffer.int.toUInt()
         val timestamp = buffer.long
         val payload = data.copyOfRange(12, data.size)
         return FoxgloveServerBinaryMessage.MessageData(

--- a/raspberry-pi-android-client/app/src/main/java/com/shusuke/raspberry_pi_client/data/infrastructure/foxglove_bridge/binary/FoxgloveBinaryMessageParser.kt
+++ b/raspberry-pi-android-client/app/src/main/java/com/shusuke/raspberry_pi_client/data/infrastructure/foxglove_bridge/binary/FoxgloveBinaryMessageParser.kt
@@ -43,7 +43,7 @@ object FoxgloveBinaryMessageParser {
             return FoxgloveServerBinaryMessage.Unknown(opcode = OPCODE_MESSAGE_DATA, error = FoxgloveBinaryParseError.InsufficientData)
         }
         val buffer = ByteBuffer.wrap(data).order(ByteOrder.LITTLE_ENDIAN)
-        val subscriptionId = buffer.int.toUInt() and 0xFFFFFFFFu
+        val subscriptionId = buffer.int.toUInt() //and 0xFFFFFFFFu
         val timestamp = buffer.long
         val payload = data.copyOfRange(12, data.size)
         return FoxgloveServerBinaryMessage.MessageData(

--- a/raspberry-pi-android-client/app/src/main/java/com/shusuke/raspberry_pi_client/data/infrastructure/ros/service/DummyEmptyService.kt
+++ b/raspberry-pi-android-client/app/src/main/java/com/shusuke/raspberry_pi_client/data/infrastructure/ros/service/DummyEmptyService.kt
@@ -6,35 +6,35 @@ import java.nio.ByteBuffer
 import java.nio.ByteOrder
 
 /**
- * `bool ignore_this_field` を持つダミーの空サービス型。
+ * `uint32 ignoreThisField` を持つダミーの空サービス型。
  *
- * CDR エンコード: header(4) + bool(1) = 5 バイト
+ * CDR エンコード: header(4) + uint32(4) = 8 バイト
  */
 @Serializable
-data class DummyEmptyService(val ignore_this_field: Boolean = false) {
+data class DummyEmptyService(val ignoreThisField: UInt = 0u) {
     companion object {
         /**
          * CDR LE バイナリにエンコードする。
          *
-         * 構造: header(4) + ignore_this_field(1)
+         * 構造: header(4) + ignoreThisField(4)
          */
         fun encodeToCdr(args: DummyEmptyService): ByteArray {
-            val buffer = ByteBuffer.allocate(4 + 1).order(ByteOrder.LITTLE_ENDIAN)
+            val buffer = ByteBuffer.allocate(4 + 4).order(ByteOrder.LITTLE_ENDIAN)
             buffer.put(CdrHelpers.encapsulationHeader)
-            buffer.put(if (args.ignore_this_field) 0x01.toByte() else 0x00.toByte())
+            buffer.putInt(args.ignoreThisField.toInt())
             return buffer.array()
         }
 
         /**
          * CDR バイナリからデコードする。
          *
-         * @param data CDR バイナリ（header 4 バイト + bool 1 バイト）
+         * @param data CDR バイナリ（header 4 バイト + uint32 4 バイト）
          * @return デコード結果。データ不足の場合はデフォルト値を返す
          */
         fun decodeFromCdr(data: ByteArray): DummyEmptyService {
-            if (data.size < 5) return DummyEmptyService()
-            val value = data[4] != 0x00.toByte()
-            return DummyEmptyService(ignore_this_field = value)
+            if (data.size < 8) return DummyEmptyService()
+            val value = ByteBuffer.wrap(data, 4, 4).order(ByteOrder.LITTLE_ENDIAN).int.toUInt()
+            return DummyEmptyService(ignoreThisField = value)
         }
     }
 }

--- a/raspberry-pi-android-client/app/src/main/java/com/shusuke/raspberry_pi_client/data/infrastructure/ros/service/DummyEmptyService.kt
+++ b/raspberry-pi-android-client/app/src/main/java/com/shusuke/raspberry_pi_client/data/infrastructure/ros/service/DummyEmptyService.kt
@@ -1,0 +1,40 @@
+package com.shusuke.raspberry_pi_client.data.infrastructure.ros.service
+
+import com.shusuke.raspberry_pi_client.data.infrastructure.ros.cdr.CdrHelpers
+import kotlinx.serialization.Serializable
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * `bool ignore_this_field` を持つダミーの空サービス型。
+ *
+ * CDR エンコード: header(4) + bool(1) = 5 バイト
+ */
+@Serializable
+data class DummyEmptyService(val ignore_this_field: Boolean = false) {
+    companion object {
+        /**
+         * CDR LE バイナリにエンコードする。
+         *
+         * 構造: header(4) + ignore_this_field(1)
+         */
+        fun encodeToCdr(args: DummyEmptyService): ByteArray {
+            val buffer = ByteBuffer.allocate(4 + 1).order(ByteOrder.LITTLE_ENDIAN)
+            buffer.put(CdrHelpers.encapsulationHeader)
+            buffer.put(if (args.ignore_this_field) 0x01.toByte() else 0x00.toByte())
+            return buffer.array()
+        }
+
+        /**
+         * CDR バイナリからデコードする。
+         *
+         * @param data CDR バイナリ（header 4 バイト + bool 1 バイト）
+         * @return デコード結果。データ不足の場合はデフォルト値を返す
+         */
+        fun decodeFromCdr(data: ByteArray): DummyEmptyService {
+            if (data.size < 5) return DummyEmptyService()
+            val value = data[4] != 0x00.toByte()
+            return DummyEmptyService(ignore_this_field = value)
+        }
+    }
+}

--- a/raspberry-pi-android-client/app/src/main/java/com/shusuke/raspberry_pi_client/data/infrastructure/util/BinaryLogHelpers.kt
+++ b/raspberry-pi-android-client/app/src/main/java/com/shusuke/raspberry_pi_client/data/infrastructure/util/BinaryLogHelpers.kt
@@ -1,0 +1,11 @@
+package com.shusuke.raspberry_pi_client.data.infrastructure.util
+
+object BinaryLogHelpers {
+
+    /**
+     * ByteArray を16進数文字列に変換する。
+     * 例: byteArrayOf(0x01, 0xAB, 0xFF) → "01 AB FF"
+     */
+    fun toHexString(data: ByteArray): String =
+        data.joinToString(" ") { "%02X".format(it) }
+}

--- a/raspberry-pi-android-client/app/src/main/java/com/shusuke/raspberry_pi_client/data/repository/turtlesim/TurtlesimRepository.kt
+++ b/raspberry-pi-android-client/app/src/main/java/com/shusuke/raspberry_pi_client/data/repository/turtlesim/TurtlesimRepository.kt
@@ -1,5 +1,6 @@
 package com.shusuke.raspberry_pi_client.data.repository.turtlesim
 
+import com.shusuke.raspberry_pi_client.data.infrastructure.ros.cdr.CdrHelpers
 import com.shusuke.raspberry_pi_client.data.infrastructure.ros.service.EmptyService
 import com.shusuke.raspberry_pi_client.data.infrastructure.ros.service.RosCallService
 import com.shusuke.raspberry_pi_client.data.infrastructure.ros.service.RosServiceError
@@ -96,6 +97,8 @@ class TurtlesimRepository(
             service = callService,
             argsSerializer = EmptyService.serializer(),
             responseSerializer = RosServiceResponse.serializer(EmptyService.serializer()),
+            cdrEncoder = { CdrHelpers.encapsulationHeader.copyOf() },
+            cdrResponseDecoder = { EmptyService },
             onMessage = { /* レスポンスは無視 */ },
         )
     }

--- a/raspberry-pi-android-client/app/src/main/java/com/shusuke/raspberry_pi_client/data/repository/turtlesim/TurtlesimRepository.kt
+++ b/raspberry-pi-android-client/app/src/main/java/com/shusuke/raspberry_pi_client/data/repository/turtlesim/TurtlesimRepository.kt
@@ -1,7 +1,6 @@
 package com.shusuke.raspberry_pi_client.data.repository.turtlesim
 
-import com.shusuke.raspberry_pi_client.data.infrastructure.ros.cdr.CdrHelpers
-import com.shusuke.raspberry_pi_client.data.infrastructure.ros.service.EmptyService
+import com.shusuke.raspberry_pi_client.data.infrastructure.ros.service.DummyEmptyService
 import com.shusuke.raspberry_pi_client.data.infrastructure.ros.service.RosCallService
 import com.shusuke.raspberry_pi_client.data.infrastructure.ros.service.RosServiceError
 import com.shusuke.raspberry_pi_client.data.infrastructure.ros.service.RosServiceResponse
@@ -89,16 +88,16 @@ class TurtlesimRepository(
      * `/reset` サービスを呼び出す。レスポンスは特に扱わない。
      */
     fun reset() {
-        val callService = RosCallService<EmptyService>(
+        val callService = RosCallService<DummyEmptyService>(
             service = "/reset",
-            args = EmptyService,
+            args = DummyEmptyService(),
         )
         connectionRepository.activeMessageClient.callService(
             service = callService,
-            argsSerializer = EmptyService.serializer(),
-            responseSerializer = RosServiceResponse.serializer(EmptyService.serializer()),
-            cdrEncoder = { CdrHelpers.encapsulationHeader.copyOf() },
-            cdrResponseDecoder = { EmptyService },
+            argsSerializer = DummyEmptyService.serializer(),
+            responseSerializer = RosServiceResponse.serializer(DummyEmptyService.serializer()),
+            cdrEncoder = { DummyEmptyService.encodeToCdr(it) },
+            cdrResponseDecoder = { DummyEmptyService.decodeFromCdr(it) },
             onMessage = { /* レスポンスは無視 */ },
         )
     }


### PR DESCRIPTION
## 課題

/clear サービスを実行するエラーとなり、spawnで生成したturtleが削除されない

**foxglove bridgeエラー**

```bash
[foxglove_bridge-1]
[foxglove_bridge-1] >>> [rcutils|error_handling.c:108] rcutils_set_error_state()
[foxglove_bridge-1] This error state is being overwritten:
[foxglove_bridge-1]
[foxglove_bridge-1]   'Handle's typesupport identifier (rosidl_typesupport_cpp) is not supported by this library, at ./src/type_support_dispatch.hpp:114'
[foxglove_bridge-1]
[foxglove_bridge-1] with this new error message:
[foxglove_bridge-1]
[foxglove_bridge-1]   'Fast CDR exception deserializing message of type std_srvs::srv::dds_::Empty_Request_., at ./src/type_support_common.cpp:118'
[foxglove_bridge-1]
[foxglove_bridge-1] rcutils_reset_error() should be called after error handling to avoid this.
[foxglove_bridge-1] <<<
[foxglove_bridge-1] [foxglove] Service handler failed: failed to desirialize request: Fast CDR exception deserializing message of type std_srvs::srv::dds_::Empty_Request_., at ./src/type_support_common.cpp:118
```

## 対策
https://github.com/Unity-Technologies/ROS-TCP-Endpoint/issues/169#issuecomment-2261893725
こちらのコメントを参考にし、適当なバイト列をヘッダーの後ろにつけて送信する

```
[header 4bytes][ignore_this_field 4byte]
 00 01 00 00    00 00 00 00
```
header(4) + ignoreThisField(4)

**結果**
/clear には成功した。Foxglove Bridgeには当該エラーが見られなかった

## 原因の深掘り
https://github.com/foxglove/ros-foxglove-bridge/issues/229